### PR TITLE
Badges with closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Filament Badgeable Column 
+# Filament Badgeable Column
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/awcodes/filament-badgeable-column.svg?style=flat-square)](https://packagist.org/packages/awcodes/filament-badgeable-column)
 [![Total Downloads](https://img.shields.io/packagist/dt/awcodes/filament-badgeable-column.svg?style=flat-square)](https://packagist.org/packages/awcodes/filament-badgeable-column)
@@ -70,10 +70,34 @@ return $table
     ]);
 ```
 
+You can also define the array of badges via a closure, if you want the array of badges to be based on dynamic data. The
+closure should return an array of `Badge` or `BadgeField` objects, similar to above.
+
+The example below assumes the records have a `BelongsToMany` relationship called `topics`, and shows how to display each
+topic name as a badge.
+
+```php
+use Awcodes\FilamentBadgeableColumn\Components\Badge;
+use Awcodes\FilamentBadgeableColumn\Components\BadgeField;
+use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;
+
+return $table
+    ->columns([
+        BadgeableColumn::make('title')
+            ->badges(function($record) {
+                  return $record->topics->map(function($topic) {
+                    return Badge::make($topic->name)->color($topic->color)
+                  });
+            })
+            ->searchable()
+            ->sortable(),
+    ]);
+```
+
 ### Badgeable Tags Column
 
-This is similar to the `Badgeable Column` except it allows you to use an 
-array of data to simply output badges in the column. You field must return 
+This is similar to the `Badgeable Column` except it allows you to use an
+array of data to simply output badges in the column. You field must return
 an array from the record.
 
 ```php
@@ -91,8 +115,8 @@ BadgeableTagsColumn::make('tags')
 
 ## Badge Shape
 
-If you prefer to have a more "square" shape you can use the `asPills()` 
-method to set the shape of the badges. The default is that each badge 
+If you prefer to have a more "square" shape you can use the `asPills()`
+method to set the shape of the badges. The default is that each badge
 will be a pill shape.
 
 ```php

--- a/src/Components/BadgeableColumn.php
+++ b/src/Components/BadgeableColumn.php
@@ -15,18 +15,23 @@ class BadgeableColumn extends TextColumn
 
     public function badges(array | Closure | null $badges): static
     {
-        foreach ($badges as $badge) {
-            $badge->column($this);
-            $badge->isPill($this->shouldBePills());
-            $this->badges[$badge->getName()] = $badge;
-        }
+        $this->badges = $badges;
 
         return $this;
     }
 
     public function getBadges(): array
     {
-        return $this->badges;
+        // only evaluate the badges here, to ensure the rest of the livewire component stack + needed data is available.
+        $badges = $this->evaluate($this->badges);
+
+        foreach ($this->badges as $badge) {
+            $badge->column($this);
+            $badge->isPill($this->shouldBePills());
+            $badges[$badge->getName()] = $badge;
+        }
+
+        return $badges;
     }
 
     public function asPills(bool | Closure | null $condition): static

--- a/src/Components/BadgeableColumn.php
+++ b/src/Components/BadgeableColumn.php
@@ -22,7 +22,7 @@ class BadgeableColumn extends TextColumn
 
     public function getBadges(): array
     {
-        // only evaluate the badges here, to ensure the rest of the livewire component stack + needed data is available.
+        // only evaluate the badges at the point of retrieval, to ensure the rest of the livewire component stack + needed data is available.
         $badges = $this->evaluate($this->badges);
 
         foreach ($this->badges as $badge) {

--- a/src/Components/BadgeableTagsColumn.php
+++ b/src/Components/BadgeableTagsColumn.php
@@ -42,17 +42,21 @@ class BadgeableTagsColumn extends Column
 
     public function badges(array | Closure | null $badges): static
     {
-        foreach ($badges as $badge) {
-            $badge->column($this);
-            $this->badges[$badge->getName()] = $badge;
-        }
+        $this->badges = $badges;
 
         return $this;
     }
 
     public function getBadges(): array
     {
-        return $this->badges;
+        $badges = $this->evaluate($this->badges);
+
+        foreach ($badges as $badge) {
+            $badge->column($this);
+            $badges[$badge->getName()] = $badge;
+        }
+
+        return $badges;
     }
 
     public function getColors(): array


### PR DESCRIPTION
Hi,

First - thank you for this plugin. It does pretty much what I need without requiring all the extra setup and use of specific "tags"  classes like the Spatie Tags package. 

I saw the `BadgeableColumn::badges()` method accepted a closure, but on trying it out it looked like it wasn't setup with that in mind, and I was getting an error:

> Typed property Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn::$badges must not be accessed before initialization

I needed this for a project I've been setting up this week, so I've put together a patch for it. Figured I could share it back here. I've added an example into the Readme too.

Thanks again!

