### PR TITLE
Feat: big enhancements

### DIFF
--- a/resources/views/components/badge.blade.php
+++ b/resources/views/components/badge.blade.php
@@ -1,17 +1,28 @@
+@php
+    use Awcodes\FilamentBadgeableColumn\Badge\BadgeSize;
+@endphp
+
 @if (! $isHidden())
     @php
-        $color = $getColor() ?? 'gray';
+        $color = $getColor();
+
+        $size = match ($size = $getSize()) {
+            BadgeSize::ExtraSmall, 'xs' => 'xs',
+            BadgeSize::Small, 'sm', null => 'sm',
+            BadgeSize::Medium, 'base', 'md' => 'md',
+            default => $size,
+        };
+
         $badgeClasses = \Illuminate\Support\Arr::toCssClasses([
-            "badger-badge px-2 inline-flex py-0.5",
-            match ($isPill = $shouldBePill()) {
-                true => 'rounded-full',
-                default => 'rounded',
+            "badger-badge",
+            match ($shouldBePill()) {
+                true => 'px-2 !rounded-full',
+                default => null,
             },
-            match ($getSize(null) ?? 'xs') {
-                'xs' => 'text-xs',
-                'sm', null => 'text-sm',
-                'base', 'md' => 'text-base',
-                'lg' => 'text-lg',
+            match ($getFontFamily(null)) {
+                'sans' => 'font-sans',
+                'serif' => 'font-serif',
+                'mono' => 'font-mono',
                 default => null,
             },
             match ($getWeight(null) ?? 'medium') {
@@ -24,23 +35,9 @@
                 'extrabold' => 'font-extrabold',
                 'black' => 'font-black',
                 default => null,
-            },
-            match ($getFontFamily(null)) {
-                'sans' => 'font-sans',
-                'serif' => 'font-serif',
-                'mono' => 'font-mono',
-                default => null,
-            },
-            match ($color) {
-                'gray' => 'bg-gray-500/10 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300',
-                default => 'bg-custom-500/10 text-custom-700 dark:text-custom-500',
-            },
+            }
         ]);
-
-        $badgeStyles = \Illuminate\Support\Arr::toCssStyles([
-            \Filament\Support\get_color_css_variables($color, shades: [300, 500, 700]) => $color !== 'gray',
-        ]);
-
     @endphp
-<span class="{{ $badgeClasses }}" style="{{ $badgeStyles }}">{{ $getLabel() }}</span>
+
+    <x-filament::badge :class="$badgeClasses" :$color :$size>{{ $getLabel() }}</x-filament::badge>
 @endif

--- a/src/Badge/BadgeSize.php
+++ b/src/Badge/BadgeSize.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Awcodes\FilamentBadgeableColumn\Badge;
+
+enum BadgeSize
+{
+    case ExtraSmall;
+
+    case Small;
+
+    case Medium;
+}

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -2,8 +2,8 @@
 
 namespace Awcodes\FilamentBadgeableColumn\Components;
 
+use Awcodes\FilamentBadgeableColumn\Badge\BadgeSize;
 use Closure;
-use Filament\Actions\Concerns\HasSize;
 use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\HasColor;
 use Filament\Tables\Columns\Column;
@@ -19,11 +19,10 @@ class Badge extends ViewComponent
 {
     use CanBeHidden;
     use HasColor;
+    use HasFontFamily;
     use HasLabel;
     use HasName;
     use HasRecord;
-    use HasFontFamily;
-    use HasSize;
     use HasWeight;
 
     protected string $view = 'filament-badgeable-column::components.badge';
@@ -31,6 +30,8 @@ class Badge extends ViewComponent
     protected Column $column;
 
     protected bool | Closure | null $shouldBePill = true;
+
+    protected BadgeSize | string | Closure | null $size = null;
 
     final public function __construct(string $name)
     {
@@ -41,6 +42,7 @@ class Badge extends ViewComponent
     {
         $static = app(static::class, ['name' => $name]);
         $static->configure();
+
         return $static;
     }
 
@@ -51,11 +53,23 @@ class Badge extends ViewComponent
         return $this;
     }
 
+    public function size(BadgeSize | string | Closure | null $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
     public function column(Column $column): static
     {
         $this->column = $column;
 
         return $this;
+    }
+
+    public function getSize(): BadgeSize | string | null
+    {
+        return $this->evaluate($this->size);
     }
 
     public function getRecord(): ?Model
@@ -74,6 +88,6 @@ class Badge extends ViewComponent
 
     public function shouldBePill(): bool
     {
-        return $this->evaluate($this->shouldBePill);
+        return (bool) $this->evaluate($this->shouldBePill);
     }
 }

--- a/src/Components/BadgeableColumn.php
+++ b/src/Components/BadgeableColumn.php
@@ -89,7 +89,7 @@ class BadgeableColumn extends TextColumn
 
     public function shouldBePills(): bool
     {
-        return $this->evaluate($this->asPills);
+        return (bool) $this->evaluate($this->asPills);
     }
 
     public function suffixBadges(array | Closure $badges): static


### PR DESCRIPTION
# Pros:

1. Use native badges.
2. Provide custom enum since badges can only have 'xs', 'sm', 'md' sizes.
3. Remove the need of using custom themes.

Before:

![Before](https://github.com/awcodes/filament-badgeable-column/assets/121197517/ce8d68d1-a8b2-4011-a06f-b95f46670ba8)

After:

![After](https://github.com/awcodes/filament-badgeable-column/assets/121197517/940e7ba7-fa33-4d26-9991-cef5371c19ea)

# Cons:

1. Used `!rounded-full` since the badge classes already uses rounded
2. `->weight(...)` doesn't work because since the badge classes already uses font-medium