### PR TITLE
Add separateWith, a method to set the separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,28 +99,6 @@ return $table
     ]);
 ```
 
-## Separator
-
-The default separator between the column text and the badges is '&mdash;'. 
-If you would like to use a different separator, use the `separateWith()`
-method to set a character or characters to be used as a separator.
-
-```php
-use Awcodes\FilamentBadgeableColumn\Components\Badge;
-use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;
-
-return $table
-    ->columns([
-        BadgeableColumn::make('name')
-            ->separateWith(':')
-
-            // or
-
-            ->separateWith()
-    ]);
-```
-
-
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ return $table
 If you prefer to have a more "rounded" shape you can use the `asPills()`
 method to set the shape of the badges.
 
+```php
+use Awcodes\FilamentBadgeableColumn\Components\Badge;
+use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;
+
+return $table
+    ->columns([
+        BadgeableColumn::make('name')
+            ->asPills()
+    ]);
+```
+
 ## Separator
 
 The default separator between the column text and the badges is '&mdash;'. 
@@ -101,9 +112,14 @@ use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;
 return $table
     ->columns([
         BadgeableColumn::make('name')
-            ->asPills()
+            ->separateWith(':')
+
+            // or
+
+            ->separateWith()
     ]);
 ```
+
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ return $table
 If you prefer to have a more "rounded" shape you can use the `asPills()`
 method to set the shape of the badges.
 
+## Separator
+
+The default separator between the column text and the badges is '&mdash;'. 
+If you would like to use a different separator, use `separateWith()`
+method to set character to be used as a separator.
+
 ```php
 use Awcodes\FilamentBadgeableColumn\Components\Badge;
 use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ return $table
 ## Separator
 
 The default separator between the column text and the badges is '&mdash;'. 
-If you would like to use a different separator, use `separateWith()`
-method to set character to be used as a separator.
+If you would like to use a different separator, use the `separateWith()`
+method to set a character or characters to be used as a separator.
 
 ```php
 use Awcodes\FilamentBadgeableColumn\Components\Badge;

--- a/src/Concerns/HasBadges.php
+++ b/src/Concerns/HasBadges.php
@@ -13,6 +13,8 @@ trait HasBadges
 
     protected bool | Closure $asPills = false;
 
+    protected ?string $badgeSeparator = '&mdash;';
+
     protected function setUp(): void
     {
         $this->html();
@@ -41,7 +43,7 @@ trait HasBadges
                 ->replace('<!-- __BLOCK__ --> ', '')
                 ->replace('<!-- __ENDBLOCK__ -->', '')
                 ->replace('<!--[if BLOCK]><![endif]-->', '')
-                ->replace('<!--[if ENDBLOCK]><![endif]-->','')
+                ->replace('<!--[if ENDBLOCK]><![endif]-->', '')
                 ->replace('/n', '')
                 ->trim();
         }
@@ -53,8 +55,10 @@ trait HasBadges
     {
         $badges = $this->getPrefixBadges();
 
+        $badgeSeparator = $this->getBadgeSeparator();
+
         if ($badges) {
-            return '<span style="display:inline-flex;gap:0.375rem;margin-inline-end:0.25rem;">' . $badges . '</span><span style="opacity: 0.375;">&mdash;</span> ' . parent::getPrefix();
+            return '<span style="display:inline-flex;gap:0.375rem;margin-inline-end:0.25rem;">' . $badges . '</span><span style="opacity: 0.375;">' . $badgeSeparator . '</span> ' . parent::getPrefix();
         }
 
         return parent::getPrefix();
@@ -69,8 +73,10 @@ trait HasBadges
     {
         $badges = $this->getSuffixBadges();
 
+        $badgeSeparator = $this->getBadgeSeparator();
+
         if ($badges) {
-            return parent::getSuffix() . ' <span style="opacity: 0.375;">&mdash;</span><span style="display:inline-flex;gap:0.375rem;margin-inline-start:0.25rem;">' . $badges . '</span>';
+            return parent::getSuffix() . ' <span style="opacity: 0.375;">' . $badgeSeparator . '</span><span style="display:inline-flex;gap:0.375rem;margin-inline-start:0.25rem;">' . $badges . '</span>';
         }
 
         return parent::getSuffix();
@@ -98,5 +104,17 @@ trait HasBadges
         $this->suffixBadges = $badges;
 
         return $this;
+    }
+
+    public function separateWith(?string $separator = null): static
+    {
+        $this->badgeSeparator = $separator;
+
+        return $this;
+    }
+
+    public function getBadgeSeparator(): ?string
+    {
+        return $this->badgeSeparator;
     }
 }

--- a/src/Concerns/HasBadges.php
+++ b/src/Concerns/HasBadges.php
@@ -13,8 +13,6 @@ trait HasBadges
 
     protected bool | Closure $asPills = false;
 
-    protected ?string $badgeSeparator = '&mdash;';
-
     protected function setUp(): void
     {
         $this->html();
@@ -55,10 +53,8 @@ trait HasBadges
     {
         $badges = $this->getPrefixBadges();
 
-        $badgeSeparator = $this->getBadgeSeparator();
-
         if ($badges) {
-            return '<span style="display:inline-flex;gap:0.375rem;margin-inline-end:0.25rem;">' . $badges . '</span><span style="opacity: 0.375;">' . $badgeSeparator . '</span> ' . parent::getPrefix();
+            return '<span style="display:inline-flex;gap:0.375rem;margin-inline-end:0.25rem;">' . $badges . '</span><span style="opacity: 0.375;">' . $this->getSeperator() . '</span> ' . parent::getPrefix();
         }
 
         return parent::getPrefix();
@@ -73,10 +69,8 @@ trait HasBadges
     {
         $badges = $this->getSuffixBadges();
 
-        $badgeSeparator = $this->getBadgeSeparator();
-
         if ($badges) {
-            return parent::getSuffix() . ' <span style="opacity: 0.375;">' . $badgeSeparator . '</span><span style="display:inline-flex;gap:0.375rem;margin-inline-start:0.25rem;">' . $badges . '</span>';
+            return parent::getSuffix() . ' <span style="opacity: 0.375;">' . $this->getSeperator() . '</span><span style="display:inline-flex;gap:0.375rem;margin-inline-start:0.25rem;">' . $badges . '</span>';
         }
 
         return parent::getSuffix();
@@ -106,15 +100,8 @@ trait HasBadges
         return $this;
     }
 
-    public function separateWith(?string $separator = null): static
+    public function getSeparator(): ?string
     {
-        $this->badgeSeparator = $separator;
-
-        return $this;
-    }
-
-    public function getBadgeSeparator(): ?string
-    {
-        return $this->badgeSeparator;
+        return $this->evaluate($this->separator) ?? '&mdash;';
     }
 }


### PR DESCRIPTION
Thanks for the really useful package.

I found that I preferred to have no separator between the text and the badges, so hence this pull request.

The added section to read me explains it's use.

> ## Separator
> The default separator between the column text and the badges is '&mdash;'. 
> If you would like to use a different separator, use `separateWith()`
> method to set the character to be used as a separator.