### PR TITLE
Add back separator() method to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ return $table
 If you prefer to have a more "rounded" shape you can use the `asPills()`
 method to set the shape of the badges.
 
+## Separator
+
+The default separator between the column text and the badges is '&mdash;'. 
+If you would like to use a different separator, use the `separator()`
+method to set character to be used as a separator.
+
 ```php
 use Awcodes\FilamentBadgeableColumn\Components\Badge;
 use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;


### PR DESCRIPTION
For some reason a few months ago this was taken out from the docs, but the function is still there.